### PR TITLE
Fixed hyperlink to the wiki

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,4 +65,4 @@ the Discord.
 
 ## Contributing to the Wiki
 This wiki was migrated from the original MediaWiki to Github Pages.
-If you would like to contribute please see https://github.com/ufscwiki/Unfavorable-Semicircle-Wiki/
+If you would like to contribute please see <https://github.com/ufscwiki/Unfavorable-Semicircle-Wiki/>


### PR DESCRIPTION
While hyperlinks do work when viewing markdown through GitHub, I noticed the link was not working when viewing the website.